### PR TITLE
Added functionality to use webpack 5 instead of 4

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  future: {
+    webpack5: false,
+  },
+};


### PR DESCRIPTION
Added functionality to use webpack 5 instead of 4, but set it to false for the time being, as there's a fs-events warning on compile.  Technically fine, but I'll wait until Next is updated to solve the warning before setting it to true. Functionality with webpack 4 is the same at the moment, so no harm done